### PR TITLE
2.1.0

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,7 +16,7 @@
     <string name="author_title">作者信息</string>
     <string name="love">如果喜欢本模块的话,欢迎进入爱发电给作者投喂!</string>
     <string name="love_url">爱发电</string>
-    <string name="xposed_description">为小米系865/870且基带版本为2.5.x,并使用MIUI的设备基带解锁一些功能,但理论上大部分MIUI13机型都可用</string>
+    <string name="xposed_description">一个适用于MIUI14的基带增强型模块，可以为您的设备开启一些基带的相关功能</string>
     <string name="tips">提示</string>
     <string name="warning">警告</string>
     <string name="not_support">您似乎正在使用过时的 LSPosed 版本或 LSPosed 未激活，请更新 LSPosed 或者激活后再试。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,6 @@
     <string name="mtb_auth_summary">(Please note that this is a highly dangerous feature, be sure to fully back up the modem before using this function! We are not responsible for modem damage caused by this function)Enter *#*#MODEMTEST#*#* on the dial interface to open the MTB Settings</string>
     <string name="more">More</string>
     <string name="finished">Finished</string>
-    <string name="xposed_description">MIUI13 Modem Feature Pro</string>
+    <string name="xposed_description">MIUI13-14 Modem Feature Pro</string>
     <string name="antique_version">Detected that unsupported miui version of your device,some settings are unavailable!</string>
 </resources>


### PR DESCRIPTION
1.更新`EzxHelper`至v2.0.6
2.更新至API 34
3.适配鲁班MTB`v6.0`
4.增加一些机型检测
以下是仅适配小米13系列机型的新功能
5.新增`智能双卡`
6.新增`机场/郊野/地铁网络场景优化`
7.新增`无视城市白名单强制支持郊野网络场景优化`
8.新增`全局5G双卡数据并发`
9.新增`全局5G双卡数据辅助`